### PR TITLE
migrate to package web for WASM support

### DIFF
--- a/lib/localized_rich_text_web.dart
+++ b/lib/localized_rich_text_web.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 // of your plugin as a separate package, instead of inlining it in the same
 // package as the core of your plugin.
 // ignore: avoid_web_libraries_in_flutter
-import 'dart:html' as html show window;
+import 'package:web/web.dart' as web show window;
 
 import 'package:flutter/services.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
@@ -39,7 +39,7 @@ class LocalizedRichTextWeb {
 
   /// Returns a [String] containing the version of the platform.
   Future<String> getPlatformVersion() {
-    final version = html.window.navigator.userAgent;
+    final version = web.window.navigator.userAgent;
     return Future.value(version);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
+  web: ^1.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Hi! Could you please review this PR? It includes a migration from dart:html to the package:web, which is necessary for building with WebAssembly. Thank you!